### PR TITLE
Build sphinx docs backwards check

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build Sphinx Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/build_sphinx_docs@v2
+      - uses: neuroinformatics-unit/actions/build_sphinx_docs@smg/doc-dependencies-as-extra
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
To check building docs with dependencies specified via `requirements.txt` file still works with new proposed action (PR [129](https://github.com/neuroinformatics-unit/actions/pull/129)).

**What does this PR do?**
Points to the updated version of the action as a test. This PR is not meant to be merged.

## References

Related to #6 

## How has this PR been tested?

It is a test in itself.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
