### PR TITLE
Upper pin sleap-io >= 0.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11.0"
 dynamic = ["version"]
 
 dependencies = [
-  "sleap-io",
+  "sleap-io>=0.6.4",
 ]
 
 license = {text = "BSD-3-Clause"}


### PR DESCRIPTION
sleap-io >= 0.6.4 supports loading multi-index DLC .csv files