### PR TITLE
Redirect baseurl to poseinterface.neuroinformatics.dev

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -122,7 +122,7 @@ html_theme_options = {
 # The default is the URL of the GitHub pages
 # https://www.sphinx-doc.org/en/master/usage/extensions/githubpages.html
 github_user = "neuroinformatics-unit"
-html_baseurl = f"https://{github_user}.github.io/{project}"
+html_baseurl = "https://poseinterface.neuroinformatics.dev"
 sitemap_url_scheme = "{link}"
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

The Sphinx docs website currently used the default GitHub pages URL, which means the website appears at <https://neuroinformatics.dev/poseinterface/>

To match our other python packages, this should be redirected to <htttps://poseinterface.neuroinformatics.dev>.

**What does this PR do?**

Sets `html_baseurl` in `conf.py` to achieve the redirection.
@adamltyson may also need to fiddle with the DNS settings?