### PR TITLE
Spec: clarify contributed vs published datasets and minor improvements

### DIFF
--- a/docs/source/benchmark-dataset.md
+++ b/docs/source/benchmark-dataset.md
@@ -161,18 +161,16 @@ All filenames follow a key-value pair convention, similar to the [BIDS standard]
 
 * The following keys are used:
 
-  | Key     | Description                                    | Examples         |
-  |---------|------------------------------------------------|-----------------|
-  | `sub`   | Subject identifier                             | `sub-001`, `sub-M708149`   |
-  | `ses`   | Session identifier                             | `ses-02`, `ses-25`, `ses-20200317`  |
-  | `cam`   | Camera identifier                              | `cam-topdown`, `cam-side2`   |
-  | `frame` | 0-based frame index in the session video        | `frame-0000`, `frame-0500`, `frame-1000`   |
-  | `start` | 0-based frame index of the first frame of a clip in the session video | `start-0000`, `start-0500`, `start-1000` |
-  | `dur`   | Clip duration in number of frames              | `dur-5`, `dur-30`         |
+  | Key     | Description                                    | Value format   | Examples         |
+  |---------|------------------------------------------------|----------------|-----------------|
+  | `sub`   | Subject identifier                             | alphanumeric   | `sub-001`, `sub-M708149`   |
+  | `ses`   | Session identifier                             | alphanumeric   | `ses-02`, `ses-25`, `ses-20200317`  |
+  | `cam`   | Camera identifier                              | alphanumeric   | `cam-topdown`, `cam-side2`   |
+  | `frame` | 0-based frame index in the session video        | numeric        | `frame-0000`, `frame-0500`, `frame-1000`   |
+  | `start` | 0-based frame index of the first frame of a clip in the session video | numeric | `start-0000`, `start-0500`, `start-1000` |
+  | `dur`   | Clip duration in number of frames              | numeric        | `dur-5`, `dur-30`         |
 
 * The keys `sub`, `ses`, and `cam` *must* appear in every filename, in that order.
-* Key values *must* be strictly alphanumeric for `sub`, `ses` and `cam` (i.e. only `A-Z`, `a-z`, `0-9`).
-* Key values *must* be strictly numeric for `frame`, `start` and `dur` (i.e. only `0-9`).
 * Filenames *must* not contain spaces.
 
 ## Label format

--- a/docs/source/benchmark-dataset.md
+++ b/docs/source/benchmark-dataset.md
@@ -179,6 +179,7 @@ All filenames follow a key-value pair convention, similar to the [BIDS standard]
 * In the published dataset, the `Train` split includes all submitted labels. The `Test` split withholds frame labels and full clip labels to support evaluation; only clip start labels (`startlabels.json`), derived from the first frame of each clip's annotations, are published.
 * Labels *must* be stored in the same folder as the corresponding frames or clips.
 * Labels *must* be stored in [COCO keypoints format](https://cocodataset.org/#format-data), with additional requirements described below. Each label file is a JSON file with `images`, `annotations`, and `categories` arrays. Image, annotation and category `id` values *must* be unique integers within a label file.
+* The `name` field in each `categories` entry *should* be the common English name of the species in lowercase (e.g. `"mouse"`, `"rat"`, `"zebrafish"`, `"macaque"`).
 
 :::{note}
 Annotation and category `id` values *should* be 1-indexed. This convention follows sleap-io's [`save_coco`](https://io.sleap.ai/latest/reference/sleap_io/io/coco/) function and avoids conflicts with models that treat category `0` as background.

--- a/docs/source/benchmark-dataset.md
+++ b/docs/source/benchmark-dataset.md
@@ -19,6 +19,43 @@ The current scope is limited to **single-animal pose estimation** from a **singl
 
 ## Folder structure
 
+:::{note}
+This specification describes both the **contributed** and the **published** versions of the dataset. Data contributors *must* provide full keypoint annotations (frame labels and clip labels) for both `Train` and `Test` splits. During the upload process, labels for the `Test` split are partially withheld to support evaluation. See [Label format](#label-format) for details.
+:::
+
+:::: {tab-set}
+
+::: {tab-item} Contributed
+```
+.
+├── Train/
+│   └── <ProjectName>/
+│       └── sub-<subjectID>_ses-<sessionID>/
+│           ├── Frames/
+│           │   ├── sub-<subjectID>_ses-<sessionID>_cam-<camID>_frame-<frameID>.png
+│           │   ├── ...
+│           │   └── sub-<subjectID>_ses-<sessionID>_cam-<camID>_framelabels.json
+│           ├── Clips/    (optional)
+│           │   ├── sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>.mp4
+│           │   ├── sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>_cliplabels.json
+│           │   └── ...
+│           └── sub-<subjectID>_ses-<sessionID>_cam-<camID>.mp4
+└── Test/
+    └── <ProjectName>/
+        └── sub-<subjectID>_ses-<sessionID>/
+            ├── Frames/
+            │   ├── sub-<subjectID>_ses-<sessionID>_cam-<camID>_frame-<frameID>.png
+            │   ├── ...
+            │   └── sub-<subjectID>_ses-<sessionID>_cam-<camID>_framelabels.json
+            ├── Clips/    (optional)
+            │   ├── sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>.mp4
+            │   ├── sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>_cliplabels.json
+            │   └── ...
+            └── sub-<subjectID>_ses-<sessionID>_cam-<camID>.mp4
+```
+:::
+
+::: {tab-item} Published
 ```
 .
 ├── Train/
@@ -45,10 +82,10 @@ The current scope is limited to **single-animal pose estimation** from a **singl
             │   └── ...
             └── sub-<subjectID>_ses-<sessionID>_cam-<camID>.mp4
 ```
-
-:::{note}
-The `Test` split follows the same structure as `Train`, but includes different label files (see [Label format](#label-format) for details).
 :::
+
+::::
+
 
 ### Train / Test
 
@@ -83,19 +120,19 @@ The `Test` split follows the same structure as `Train`, but includes different l
 
 ### Session video
 
-* All video files (session videos and clips) *should* be in MP4 format (H.264 codec, yuv420p pixel format). Contributors *should* re-encode their videos to this format before submission (see [SLEAP documentation](https://docs.sleap.ai/latest/help/#usage) for guidance).
+* All video files (session videos and clips) *should* be in MP4 format (H.264 codec, yuv420p pixel format). Data contributors *should* re-encode their videos to this format before submission (see [SLEAP documentation](https://docs.sleap.ai/latest/help/#usage) for guidance).
 * Session video filenames *must* follow the pattern: `sub-<subjectID>_ses-<sessionID>_cam-<camID>.mp4`.
 
 ### Frames
 
-The `Frames` folder contains individually sampled images. In the `Train` split, it also contains a label file with keypoint annotations.
+The `Frames` folder contains individually sampled images and their label files.
 
 * Frames *must* be extracted from the session video.
 * Frame images *should* be in PNG format (`.png`). JPEG format (`.jpg` or `.jpeg`) *may* also be used.
 * Frame image filenames *must* follow the pattern: `sub-<subjectID>_ses-<sessionID>_cam-<camID>_frame-<frameID>.<ext>`, where `<ext>` is `.png`, `.jpg`, or `.jpeg`.
 * `<frameID>` *must* be the 0-based index of the frame in the session video.
 * `<frameID>` *must* be padded to a consistent width across all frame files within a session (e.g. `0000`, `1000`).
-* In the `Train` split, a single label file *must* be provided per camera view, named `sub-<subjectID>_ses-<sessionID>_cam-<camID>_framelabels.json`. At present, only one camera view is included, so the split contains exactly one such label file. See [Frame labels](target-framelabels) for details.
+* One frame label file (named `sub-<subjectID>_ses-<sessionID>_cam-<camID>_framelabels.json`) *must* be provided per camera view. At present, only one camera view is included, so each split contains exactly one such file. See [Label format](#label-format) for differences between contributed and published versions.
 
 ### Clips
 
@@ -105,9 +142,7 @@ A session *may* include a `Clips` folder containing short video segments and the
 * Clip filenames *must* follow the pattern: `sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>.mp4`.
 * `<frameID>` in the `start` field *must* be the 0-based index of the first frame of the clip in the session video, padded to a consistent width (e.g. `0500`, `1000`).
 * `<nFrames>` in the `dur` field *must* be the duration of the clip in number of frames (e.g. `5`, `30`).
-* A single label file *must* be provided per clip:
-  * In the `Train` split, the file is named `sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>_cliplabels.json` and contains keypoint annotations for every frame in the clip. See [Clip labels](target-cliplabels) for details.
-  * In the `Test` split, the file is named `sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>_startlabels.json` and contains keypoint annotations only for the first frame of the clip. See [Clip start labels](target-startlabels) for details.
+* One clip label file (named `sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>_cliplabels.json`) *must* be provided per clip. See [Label format](#label-format) for differences between contributed and published versions.
 
 ## File naming
 
@@ -142,8 +177,8 @@ All filenames follow a key-value pair convention, similar to the [BIDS standard]
 
 ## Label format
 
-* The `Train` split includes ground-truth keypoint annotations both for the sampled frames (`framelabels.json`) and for entire clips (`cliplabels.json`), if present.
-* The `Test` split includes keypoint annotations only for the first frame of each clip (`startlabels.json`), if clips are present. Labels for frames and entire clips are withheld to support evaluation of pose estimation and point tracking methods.
+* Data contributors *must* provide ground-truth keypoint annotations for both `Train` and `Test` splits: frame labels (`framelabels.json`) for sampled frames, and clip labels (`cliplabels.json`) for entire clips, if present.
+* In the published dataset, the `Train` split includes all submitted labels. The `Test` split withholds frame labels and full clip labels to support evaluation; only clip start labels (`startlabels.json`), derived from the first frame of each clip's annotations, are published.
 * Labels *must* be stored in the same folder as the corresponding frames or clips.
 * Labels *must* be stored in [COCO keypoints format](https://cocodataset.org/#format-data), with additional requirements described below. Each label file is a JSON file with `images`, `annotations`, and `categories` arrays. Image, annotation and category `id` values *must* be unique integers within a label file.
 
@@ -156,7 +191,6 @@ Image `id` values are always 0-indexed. The indexing origin differs for frame la
 (target-framelabels)=
 ### Frame labels (`framelabels.json`)
 
-* Frame labels *must* only exist in the `Train` split.
 * Within the `Frames` folder, there *must* be one frame label file per camera view, named `sub-<subjectID>_ses-<sessionID>_cam-<camID>_framelabels.json`.
 * Each entry in the `images` array *must* have an `id` equal to the 0-based frame index in the session video (matching the `<frameID>` in the corresponding image filename).
 * Each entry in the `images` array *must* have a `file_name` that exactly matches the name of an existing [frame image](#frames) in the `Frames` folder (including the extension).
@@ -182,7 +216,6 @@ Here each `id` is the 0-based frame index in the session video (matching the `<f
 (target-cliplabels)=
 ### Clip labels (`cliplabels.json`)
 
-* Clip labels *must* only exist in the `Train` split.
 * If a `Clips` folder is present, there *must* be one clip label file per clip, named `sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>_cliplabels.json`.
 * The `images` array *must* contain an entry for every frame in the clip, in consecutive, monotonically increasing order (covering the entire clip duration).
 * Clip labels follow the same COCO keypoints format as frame labels, but with different conventions for image `id` and `file_name` values:
@@ -212,10 +245,8 @@ Here `id: 0` through `id: 4` are the local clip indices, while `frame-1000` thro
 (target-startlabels)=
 ### Clip start labels (`startlabels.json`)
 
-* Clip start labels *must* only exist in the `Test` split.
-* If a `Clips` folder is present, there *must* be one clip start label file per clip, named `sub-<subjectID>_ses-<sessionID>_cam-<camID>_start-<frameID>_dur-<nFrames>_startlabels.json`.
-* Clip start labels provide keypoint annotations for the **first frame of the clip only**. They are intended for point-tracker evaluation, where the annotated points serve as the initial positions from which a tracker should propagate.
-* Clip start labels are identical to [Clip labels](target-cliplabels), except that the `images` array *must* contain exactly one entry corresponding to the first frame of the clip, and therefore must have `id: 0`.
+* Clip start labels only exist in the published `Test` split and are derived automatically from the contributed [clip labels](target-cliplabels) during the upload process.
+* They are identical to [clip labels](target-cliplabels), except that the `images` array *must* contain exactly one entry (the first frame of the clip, with `id: 0`). They are intended for point-tracker evaluation, where the annotated points serve as the initial positions from which a tracker should propagate.
 
 :::{admonition} Example
 :class: tip
@@ -238,8 +269,45 @@ For a clip starting at frame 1000 with a duration of 5 frames, the `images` arra
 
 ## Example
 
-Below is a concrete example project structure:
+Below is a concrete example:
 
+:::: {tab-set}
+
+::: {tab-item} Contributed
+```
+.
+├── Train/
+│   └── SWC-plusmaze/
+│       └── sub-M708149_ses-20200317/
+│           ├── Frames/
+│           │   ├── sub-M708149_ses-20200317_cam-topdown_frame-01000.png
+│           │   ├── sub-M708149_ses-20200317_cam-topdown_frame-02300.png
+│           │   ├── sub-M708149_ses-20200317_cam-topdown_frame-03500.png
+│           │   ├── sub-M708149_ses-20200317_cam-topdown_frame-07200.png
+│           │   ├── sub-M708149_ses-20200317_cam-topdown_frame-19800.png
+│           │   └── sub-M708149_ses-20200317_cam-topdown_framelabels.json
+│           ├── Clips/
+│           │   ├── sub-M708149_ses-20200317_cam-topdown_start-1000_dur-5.mp4
+│           │   └── sub-M708149_ses-20200317_cam-topdown_start-1000_dur-5_cliplabels.json
+│           └── sub-M708149_ses-20200317_cam-topdown.mp4
+└── Test/
+    └── SWC-plusmaze/
+        └── sub-M235678_ses-20210415/
+            ├── Frames/
+            │   ├── sub-M235678_ses-20210415_cam-topdown_frame-00500.png
+            │   ├── sub-M235678_ses-20210415_cam-topdown_frame-01200.png
+            │   ├── sub-M235678_ses-20210415_cam-topdown_frame-04800.png
+            │   ├── sub-M235678_ses-20210415_cam-topdown_frame-09100.png
+            │   ├── sub-M235678_ses-20210415_cam-topdown_frame-15300.png
+            │   └── sub-M235678_ses-20210415_cam-topdown_framelabels.json
+            ├── Clips/
+            │   ├── sub-M235678_ses-20210415_cam-topdown_start-0500_dur-5.mp4
+            │   └── sub-M235678_ses-20210415_cam-topdown_start-0500_dur-5_cliplabels.json
+            └── sub-M235678_ses-20210415_cam-topdown.mp4
+```
+:::
+
+::: {tab-item} Published
 ```
 .
 ├── Train/
@@ -270,3 +338,6 @@ Below is a concrete example project structure:
             │   └── sub-M235678_ses-20210415_cam-topdown_start-0500_dur-5_startlabels.json
             └── sub-M235678_ses-20210415_cam-topdown.mp4
 ```
+:::
+
+::::

--- a/docs/source/benchmark-dataset.md
+++ b/docs/source/benchmark-dataset.md
@@ -184,6 +184,8 @@ All filenames follow a key-value pair convention, similar to the [BIDS standard]
 Annotation and category `id` values *should* be 1-indexed. This convention follows sleap-io's [`save_coco`](https://io.sleap.ai/latest/reference/sleap_io/io/coco/) function and avoids conflicts with models that treat category `0` as background.
 
 Image `id` values are always 0-indexed. The indexing origin differs for frame labels and clip labels, and clip start labels follow the same conventions as clip labels. Details are provided below.
+
+Complete examples of label files are available in the repository under [tests/data/Train](repo:tree/main/tests/data/Train).
 :::
 
 (target-framelabels)=
@@ -267,7 +269,7 @@ For a clip starting at frame 1000 with a duration of 5 frames, the `images` arra
 
 ## Example
 
-Below is a concrete example:
+Below is a concrete example. A matching example dataset (with label files) is available in the repository under [tests/data/Train](repo:tree/main/tests/data/Train).
 
 :::: {tab-set}
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -176,6 +176,10 @@ myst_url_schemes = {
     "https": None,
     "ftp": None,
     "mailto": None,
+    "repo": (
+        "https://github.com/neuroinformatics-unit/poseinterface/"
+        "{{path}}#{{fragment}}"
+    ),
     "github-docs": (
         "https://docs.github.com/en/"
         "{{path}}#{{fragment}}"

--- a/tests/data/Train/SWC-plusmaze/sub-M708149_ses-20200317/Clips/sub-M708149_ses-20200317_cam-topdown_start-1000_dur-5_cliplabels.json
+++ b/tests/data/Train/SWC-plusmaze/sub-M708149_ses-20200317/Clips/sub-M708149_ses-20200317_cam-topdown_start-1000_dur-5_cliplabels.json
@@ -236,7 +236,7 @@
   "categories": [
     {
       "id": 1,
-      "name": "skeleton_1",
+      "name": "mouse",
       "keypoints": [
         "centre",
         "lateral_left",

--- a/tests/data/Train/SWC-plusmaze/sub-M708149_ses-20200317/Frames/sub-M708149_ses-20200317_cam-topdown_framelabels.json
+++ b/tests/data/Train/SWC-plusmaze/sub-M708149_ses-20200317/Frames/sub-M708149_ses-20200317_cam-topdown_framelabels.json
@@ -236,7 +236,7 @@
   "categories": [
     {
       "id": 1,
-      "name": "skeleton_1",
+      "name": "mouse",
       "keypoints": [
         "centre",
         "lateral_left",


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

Addresses feedback from @themattinthehatt (see #41) on the benchmark dataset specification.

**What does this PR do?**

Updates the benchmark dataset spec (`docs/source/benchmark-dataset.md`) and related files based on reviewer suggestions:

- [`57ff664`](https://github.com/neuroinformatics-unit/poseinterface/pull/42/commits/57ff6642569a0a6a73ac7a1d40b680cf450e46d1) *Contributed vs published distinction*: The spec now clearly distinguishes between the **contributed** dataset (what data contributors submit, with full labels for both `Train` and `Test` splits) and the **published** dataset (where `Test` labels are partially withheld). Folder structure diagrams and the concrete example use sphinx-design tabs to show both versions side by side (see first screenshot below).
- [`22378cc`](https://github.com/neuroinformatics-unit/poseinterface/pull/42/commits/22378cce8fc427fadcf340a33ddf9f17ec98a220) *File naming table*: Added a "Value format" column (alphanumeric/numeric) to the key-value table, making validation requirements more discoverable. Simplified the bullet points below the table accordingly (see second screenshot below).
- [`e686e00`](https://github.com/neuroinformatics-unit/poseinterface/pull/42/commits/e686e005f02c872b673ffde8fd6b36074ed4dfdd) *Links to test data*: Added a `repo` URL scheme in `conf.py` and linked to `tests/data/Train` from the Label format section and the Example section, so readers can see complete label files (including `categories` and `annotations` arrays).
- [`2cad418`](https://github.com/neuroinformatics-unit/poseinterface/pull/42/commits/2cad418e38c64e3a29fea64af249e27dcbb19a8e) *Category name recommendation*: The spec now recommends using the common English species name in lowercase (e.g. `"mouse"`) as the category `name` in label files. Updated the test data label files from `"skeleton_1"` to `"mouse"`.


<img width="939" height="809" alt="image" src="https://github.com/user-attachments/assets/09ed5c0a-1156-4672-9df0-b1a49cff6724" />

<img width="912" height="478" alt="image" src="https://github.com/user-attachments/assets/f92cd041-a6ec-4715-a917-5e7e70b107e0" />

## References

Closes https://github.com/neuroinformatics-unit/poseinterface/issues/41.

## How has this PR been tested?

Local documentation build. To reproduce:

```bash
uv sync --all-extras
source .venv/bin/activate  # or .venv\Scripts\activate on Windows
cd docs
make clean html
```

Then preview at `docs/build/html/index.html`.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

This PR *is* a documentation update.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
