### PR TITLE
Add installation instructions in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing
 
-See the [Contributing Guide](https://poseinterface.neuroinformatics.dev/about/contributing.html)
+See the [Contributing Guide](https://poseinterface.neuroinformatics.dev/contributing.html)
 on our website for detailed instructions.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ source .venv/bin/activate  # On macOS and Linux
 .venv\Scripts\activate     # On Windows PowerShell
 ```
 
-Then, install the package directly from GitHub:
+Then, install the package directly from the `main` branch on GitHub:
 
 ```bash
 uv pip install git+https://github.com/neuroinformatics-unit/poseinterface.git@main

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ source .venv/bin/activate  # On macOS and Linux
 Then, install the package directly from GitHub:
 
 ```bash
-uv pip install git+https://github.com/neuroinformatics-unit/poseinterface.git
+uv pip install git+https://github.com/neuroinformatics-unit/poseinterface.git@main
 ```
 
 If you would like to contribute, see the

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Read the [documentation](https://poseinterface.neuroinformatics.dev/) for more i
 > The API is not stable and may change without warning.
 > Use with caution.
 
+## Installation
+
+You can install the ``poseinterface`` package directly from GitHub using pip:
+
+```bash
+pip install git+https://github.com/neuroinformatics-unit/poseinterface.git
+```
+
+If you would like to contribute, see the
+[contributing guide](https://poseinterface.neuroinformatics.dev/contributing.html),
+which includes instructions for setting up a development environment.
+
 ## License
 ⚖️ [BSD 3-Clause](./LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,20 @@ Read the [documentation](https://poseinterface.neuroinformatics.dev/) for more i
 
 ## Installation
 
-You can install the ``poseinterface`` package directly from GitHub using pip:
+We recommend installing `poseinterface` in a virtual environment, using [uv](https://docs.astral.sh/uv/).
+
+In your working directory, create a new environment and activate it:
 
 ```bash
-pip install git+https://github.com/neuroinformatics-unit/poseinterface.git
+uv venv --python=3.13
+source .venv/bin/activate  # On macOS and Linux
+.venv\Scripts\activate     # On Windows PowerShell
+```
+
+Then, install the package directly from GitHub:
+
+```bash
+uv pip install git+https://github.com/neuroinformatics-unit/poseinterface.git
 ```
 
 If you would like to contribute, see the


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

I realised we don't have any sort of installation instructions. This was mostly fine, since the package is not yet on PyPI and probably has no users other than us, but that's about to change. We're planning to share this repo with collaborators soon, who will try to use it to contribute data.

**What does this PR do?**

- Adds some minimal installation instructions in the README, for creating a venv with `uv` and installing the package directly from GitHub
- Fixes a broken link to the contributing guide.

It DOES NOT add an installation guide to the docs; That will follow after we publish the package on PyPI.

## References

N/A

## How has this PR been tested?

I reproduced the installation steps locally.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
