### PR TITLE
Pin sleap-io>=0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version"]
 dependencies = [
   "jupyter>=1.1.1",
   "movement>=0.16.0",
-  "sleap-io>=0.6.4",
+  "sleap-io>=0.7.1",
 ]
 
 license = {text = "BSD-3-Clause"}


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Closes #44 

**What does this PR do?**
The issue is resolved upstream in [sleap-io v0.7.1](https://github.com/talmolab/sleap-io/releases/tag/v0.7.1).
This PR updates the sleap-io upper pin in pyproject.toml to v0.7.1

## How has this PR been tested?
pytest passes with the minimal reproduction example in #44 

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
