### PR TITLE
Pin movement to >0.17.0 and rename dims to singular

### DIFF
--- a/poseinterface/io.py
+++ b/poseinterface/io.py
@@ -639,8 +639,8 @@ def _convert_movement_ds_to_videolabels(
     positions = ds["position"].values  # (time, space, keypoints, individuals)
     n_frames = positions.shape[0]
 
-    keypoint_names = ds.coords["keypoints"].values.tolist()
-    individual_names = ds.coords["individuals"].values.tolist()
+    keypoint_names = ds.coords["keypoint"].values.tolist()
+    individual_names = ds.coords["individual"].values.tolist()
 
     # Build categories list (one entry per individual)
     # NOTE: categories are 1-indexed to avoid conflicts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = ["version"]
 
 dependencies = [
   "jupyter>=1.1.1",
-  "movement>=0.16.0",
+  "movement>=0.17.0",
   "sleap-io>=0.7.1",
 ]
 

--- a/tests/test_unit/test_io.py
+++ b/tests/test_unit/test_io.py
@@ -68,19 +68,19 @@ def sample_movement_ds():
     return xr.Dataset(
         {
             "position": (
-                ["time", "space", "keypoints", "individuals"],
+                ["time", "space", "keypoint", "individual"],
                 position_array,
             ),
             "confidence": (
-                ["time", "keypoints", "individuals"],
+                ["time", "keypoint", "individual"],
                 confidence_array,
             ),
         },
         coords={
             "time": [0, 1],
             "space": ["x", "y"],
-            "keypoints": ["Nose", "Tail"],
-            "individuals": ["id_0"],
+            "keypoint": ["Nose", "Tail"],
+            "individual": ["id_0"],
         },
     )
 
@@ -840,22 +840,22 @@ def test_convert_movement_ds_to_videolabels(
         assert coco_data["images"][k]["width"] == img_w
         assert coco_data["images"][k]["height"] == img_h
 
-    assert len(coco_data["categories"]) == len(ds.individuals)
-    assert coco_data["categories"][0]["name"] == ds.individuals.values[0]
+    assert len(coco_data["categories"]) == len(ds.individual)
+    assert coco_data["categories"][0]["name"] == ds.individual.values[0]
     assert (
-        coco_data["categories"][0]["keypoints"] == ds.keypoints.values.tolist()
+        coco_data["categories"][0]["keypoints"] == ds.keypoint.values.tolist()
     )
 
     # 2 frames x 1 individual = 2 annotations
-    assert len(coco_data["annotations"]) == len(ds.time) * len(ds.individuals)
+    assert len(coco_data["annotations"]) == len(ds.time) * len(ds.individual)
 
     # Frame 0: both keypoints visible, kpt0=(10, 30), kpt1=(20, 40)
     annot0 = coco_data["annotations"][0]
     assert annot0["num_keypoints"] == 2
     assert annot0["keypoints"] == [
-        *ds.position.isel(time=0, keypoints=0, individuals=0).values.tolist(),
+        *ds.position.isel(time=0, keypoint=0, individual=0).values.tolist(),
         2.0,
-        *ds.position.isel(time=0, keypoints=1, individuals=0).values.tolist(),
+        *ds.position.isel(time=0, keypoint=1, individual=0).values.tolist(),
         2.0,
     ]
     # bbox: [xmin, ymin, width, height]
@@ -869,7 +869,7 @@ def test_convert_movement_ds_to_videolabels(
         0.0,
         0.0,
         0.0,
-        *ds.position.isel(time=1, keypoints=1, individuals=0).values.tolist(),
+        *ds.position.isel(time=1, keypoint=1, individual=0).values.tolist(),
         2.0,
     ]
     # bbox covers only the single visible keypoint


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

[movement v0.1.70](https://github.com/neuroinformatics-unit/movement/releases/tag/v0.17.0) introduced an important breaking change.

> The xarray dimension names "keypoints" and "individuals" have been renamed to "keypoint" and "individual", following standard pandas/xarray conventions where dimensions represent variable names, not collections.

**What does this PR do?**

- Pins the `movement` dependency in `pyproject.toml` to `>=0.17.0` 
- Renames all occurrences of the dimensions names `individuals` and `keypoints` to the singular forms `individual` and `keypoint`

Merging this PR may cause some workflows to break, but in most cases a simple dimension rename will fix them.

## References

Needed to unblock #57 and #56 

## How has this PR been tested?

Existing tests pass locally. 

## Is this a breaking change?

Yes!

## Does this PR require an update to the documentation?

No, but I've checked that docs build succesfully locally.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
