### PR TITLE
Enable pre-commit.ci and configure mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,9 @@ repos:
       hooks:
           - id: mypy
             additional_dependencies:
+                - pandas-stubs
                 - types-setuptools
+                - xarray
     - repo: https://github.com/mgedmin/check-manifest
       rev: "0.50"
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ exclude: 'conf.py'
 # Configuring https://pre-commit.ci/
 ci:
     autoupdate_schedule: monthly
+    skip: [mypy] # Build exceeds tier max size 250MiB
 
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -44,6 +44,12 @@ git add .
 pre-commit run
 ```
 
+These hooks also run automatically on every pull request via
+[pre-commit.ci](https://pre-commit.ci/) (except `mypy`, which is skipped there
+but still runs locally and in the test workflow). If a hook auto-fixes
+something, the bot will push the fix to your branch, so remember to pull before
+continuing to work.
+
 If a problem cannot be auto-fixed, the corresponding tool will provide
 information on what the issue is and how to fix it. For example, `ruff` might
 output something like:


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: dev tools

**Why is this PR needed?**

Closes #60

**What does this PR do?**

- Applies the same pre-commit.ci config as for `movement`( skipping `mypy` on CI because the build may exceeds the pre-commit.ci 250 MiB tier limit). I've also enabled the pre-commit.ci app in GitHub settings.
- Adds `pandas-stubs` and `xarray` to the `mypy` hook's `additional_dependencies`. These are the only typed dependencies from [movement#721](https://github.com/neuroinformatics-unit/movement/pull/721) that correspond to libraries `poseinterface` actually imports (`pandas` and `xarray` in `io.py`). With the stubs present, `mypy` type-checks against real type information for these libraries instead of silently treating them as `Any`.

## References

Inspired by https://github.com/neuroinformatics-unit/movement/pull/721

## How has this PR been tested?

- `pre-commit run --all-files` passes locally.
- pre-commit.ci app runs among this PR's checks

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

I've added a sentence to the contributing guide mentioning `pre-commit.ci`.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)