### PR TITLE
Add functions to extract first frame labels from cliplabels

### DIFF
--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -29,6 +29,22 @@ clips
     extract_single_clip
     extract_clips
     extract_clips_uniform
+    extract_startlabels
+    extract_startlabels_s3
+
+
+s3
+--
+
+.. currentmodule:: poseinterface.s3
+
+.. autosummary::
+    :toctree: api_generated
+    :template: function.rst
+
+    parse_s3_uri
+    download_json_from_s3
+    upload_json_to_s3
 
 
 utils

--- a/poseinterface/clips.py
+++ b/poseinterface/clips.py
@@ -11,28 +11,6 @@ import sleap_io as sio
 from . import s3
 
 
-def _suffix_error(name: str, suffix: str) -> str:
-    return f"File must end with '{suffix}', got {name}"
-
-
-def _extract_startlabels_from_dict(clip_labels: dict) -> dict:
-    start_images = [img for img in clip_labels["images"] if img["id"] == 0]
-    if len(start_images) != 1:
-        raise ValueError(
-            "Clip labels must contain exactly one first-frame image with id 0"
-        )
-
-    return {
-        "images": start_images,
-        "annotations": [
-            annot
-            for annot in clip_labels["annotations"]
-            if annot["image_id"] == 0
-        ],
-        "categories": clip_labels["categories"],
-    }
-
-
 def _validate_clip_request(start_frame: int, duration: int) -> None:
     if start_frame < 0:
         raise ValueError(
@@ -302,6 +280,28 @@ def _extract_cliplabels(
         json.dump(clip_labels, f)
 
     return clip_json
+
+
+def _suffix_error(name: str, suffix: str) -> str:
+    return f"File must end with '{suffix}', got {name}"
+
+
+def _extract_startlabels_from_dict(clip_labels: dict) -> dict:
+    start_images = [img for img in clip_labels["images"] if img["id"] == 0]
+    if len(start_images) != 1:
+        raise ValueError(
+            "Clip labels must contain exactly one first-frame image with id 0"
+        )
+
+    return {
+        "images": start_images,
+        "annotations": [
+            annot
+            for annot in clip_labels["annotations"]
+            if annot["image_id"] == 0
+        ],
+        "categories": clip_labels["categories"],
+    }
 
 
 def extract_startlabels(

--- a/poseinterface/clips.py
+++ b/poseinterface/clips.py
@@ -8,6 +8,30 @@ from pathlib import Path
 
 import sleap_io as sio
 
+from . import s3
+
+
+def _suffix_error(name: str, suffix: str) -> str:
+    return f"File must end with '{suffix}', got {name}"
+
+
+def _extract_startlabels_from_dict(clip_labels: dict) -> dict:
+    start_images = [img for img in clip_labels["images"] if img["id"] == 0]
+    if len(start_images) != 1:
+        raise ValueError(
+            "Clip labels must contain exactly one first-frame image with id 0"
+        )
+
+    return {
+        "images": start_images,
+        "annotations": [
+            annot
+            for annot in clip_labels["annotations"]
+            if annot["image_id"] == 0
+        ],
+        "categories": clip_labels["categories"],
+    }
+
 
 def _validate_clip_request(start_frame: int, duration: int) -> None:
     if start_frame < 0:
@@ -278,6 +302,149 @@ def _extract_cliplabels(
         json.dump(clip_labels, f)
 
     return clip_json
+
+
+def extract_startlabels(
+    cliplabels_path: str | Path, output_path: str | Path | None = None
+) -> Path:
+    """Extract only the first frame's labels from a cliplabels.json file.
+
+    Reads a ``*_cliplabels.json`` file and creates a corresponding
+    ``*_startlabels.json`` file containing only the labels for the first
+    frame (frame with id=0).
+
+    Parameters
+    ----------
+    cliplabels_path
+        Path to the input ``*_cliplabels.json`` file.
+    output_path
+        Path to the output ``*_startlabels.json`` file. If ``None``
+        (default), it is derived from ``cliplabels_path`` by replacing
+        ``_cliplabels.json`` with ``_startlabels.json``.
+
+    Returns
+    -------
+    Path
+        Path to the output ``*_startlabels.json`` file.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the input file does not exist.
+    ValueError
+        If the input filename does not end with ``_cliplabels.json``,
+        ``output_path`` does not end with ``_startlabels.json``, or the
+        clip labels do not contain exactly one first-frame image (``id: 0``).
+    """
+    cliplabels_path = Path(cliplabels_path)
+
+    # Validate input file exists
+    if not cliplabels_path.exists():
+        raise FileNotFoundError(f"Input file not found: {cliplabels_path}")
+
+    # Validate input filename
+    if not cliplabels_path.name.endswith("_cliplabels.json"):
+        raise ValueError(
+            _suffix_error(cliplabels_path.name, "_cliplabels.json")
+        )
+
+    # Read the cliplabels file
+    with open(cliplabels_path) as f:
+        clip_labels = json.load(f)
+
+    start_labels = _extract_startlabels_from_dict(clip_labels)
+
+    # Generate output path by replacing _cliplabels.json with _startlabels.json
+    if output_path is None:
+        output_path = cliplabels_path.parent / cliplabels_path.name.replace(
+            "_cliplabels.json", "_startlabels.json"
+        )
+    else:
+        output_path = Path(output_path)
+        if not output_path.name.endswith("_startlabels.json"):
+            raise ValueError(
+                _suffix_error(output_path.name, "_startlabels.json")
+            )
+
+    # Save the start labels
+    with open(output_path, "w") as f:
+        json.dump(start_labels, f)
+
+    logging.info(
+        f"Extracted start frame labels from {cliplabels_path.name} "
+        f"to {output_path.name}"
+    )
+
+    return output_path
+
+
+def extract_startlabels_s3(
+    s3_cliplabels_uri: str,
+    output_uri: str | None = None,
+    aws_profile: str | None = None,
+) -> str:
+    """Extract first frame's labels from a cliplabels.json file on S3.
+
+    Reads a ``*_cliplabels.json`` file from S3 and creates a corresponding
+    ``*_startlabels.json`` file on S3 containing only the labels for the first
+    frame (frame with id=0).
+
+    Parameters
+    ----------
+    s3_cliplabels_uri
+        S3 URI of the input ``*_cliplabels.json`` file in the format
+        ``s3://bucket-name/path/to/file_cliplabels.json``.
+    output_uri
+        Optional S3 URI for the output file. If ``None`` (default), it is
+        derived from the ``s3_cliplabels_uri`` by replacing
+        ``_cliplabels.json`` with ``_startlabels.json``.
+    aws_profile
+        Optional AWS profile name to use for authentication. If None, uses
+        the default AWS credentials chain.
+
+    Returns
+    -------
+    str
+        S3 URI of the output ``*_startlabels.json`` file.
+
+    Raises
+    ------
+    ValueError
+        If the S3 URI format is invalid, the input filename does not end
+        with ``_cliplabels.json``, ``output_uri`` does not end with
+        ``_startlabels.json``, or the clip labels do not contain exactly
+        one first-frame image (``id: 0``).
+    FileNotFoundError
+        If the input file does not exist on S3.
+    ClientError
+        If there are other S3 access issues (e.g. permissions).
+    """
+    # Parse S3 URI and validate filename
+    bucket_name, key = s3.parse_s3_uri(s3_cliplabels_uri)
+    if not key.endswith("_cliplabels.json"):
+        raise ValueError(_suffix_error(key, "_cliplabels.json"))
+
+    # Download cliplabels from S3
+    clip_labels = s3.download_json_from_s3(bucket_name, key, aws_profile)
+
+    # Extract start labels using local function
+    start_labels = _extract_startlabels_from_dict(clip_labels)
+
+    # Generate output key/URI if not provided
+    if output_uri is None:
+        output_key = key.replace("_cliplabels.json", "_startlabels.json")
+        output_uri = f"s3://{bucket_name}/{output_key}"
+    else:
+        _, output_key = s3.parse_s3_uri(output_uri)
+        if not output_key.endswith("_startlabels.json"):
+            raise ValueError(_suffix_error(output_key, "_startlabels.json"))
+
+    # Upload start labels to S3
+    s3.upload_json_to_s3(start_labels, bucket_name, output_key, aws_profile)
+
+    logging.info(f"Extracted start frame labels from {key} to {output_key}")
+
+    return output_uri
 
 
 def main(args: argparse.Namespace) -> None:

--- a/poseinterface/s3.py
+++ b/poseinterface/s3.py
@@ -1,0 +1,123 @@
+"""S3 utilities for poseinterface."""
+
+import json
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+def parse_s3_uri(s3_uri: str) -> tuple[str, str]:
+    """Parse an S3 URI into bucket and key components.
+
+    Parameters
+    ----------
+    s3_uri
+        S3 URI in the format ``s3://bucket-name/path/to/file``.
+
+    Returns
+    -------
+    tuple[str, str]
+        Tuple of (bucket_name, key).
+
+    Raises
+    ------
+    ValueError
+        If the S3 URI format is invalid.
+    """
+    if not s3_uri.startswith("s3://"):
+        raise ValueError(
+            f"Invalid S3 URI format. Expected 's3://bucket/key', got {s3_uri}"
+        )
+
+    uri_parts = s3_uri[5:].split("/", 1)
+    if len(uri_parts) != 2:
+        raise ValueError(
+            f"Invalid S3 URI format. Expected 's3://bucket/key', got {s3_uri}"
+        )
+
+    return uri_parts[0], uri_parts[1]
+
+
+def download_json_from_s3(
+    bucket_name: str, key: str, aws_profile: str | None = None
+) -> dict:
+    """Download and parse a JSON file from S3.
+
+    Parameters
+    ----------
+    bucket_name
+        Name of the S3 bucket.
+    key
+        S3 object key (path within the bucket).
+    aws_profile
+        Optional AWS profile name to use for authentication.
+
+    Returns
+    -------
+    dict
+        Parsed JSON content.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist on S3.
+    ClientError
+        If there are other S3 access issues.
+    """
+    session = boto3.Session(profile_name=aws_profile)
+    s3_client = session.client("s3")
+
+    try:
+        logging.info(f"Downloading s3://{bucket_name}/{key}")
+        response = s3_client.get_object(Bucket=bucket_name, Key=key)
+        return json.loads(response["Body"].read().decode("utf-8"))
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        if error_code == "NoSuchKey":
+            raise FileNotFoundError(
+                f"File not found on S3: s3://{bucket_name}/{key}"
+            ) from e
+        logging.error(
+            "Failed to download from s3://%s/%s (S3 error: %s)",
+            bucket_name,
+            key,
+            error_code,
+        )
+        raise
+
+
+def upload_json_to_s3(
+    data: dict,
+    bucket_name: str,
+    key: str,
+    aws_profile: str | None = None,
+) -> None:
+    """Upload a JSON object to S3.
+
+    Parameters
+    ----------
+    data
+        Dictionary to serialize and upload.
+    bucket_name
+        Name of the S3 bucket.
+    key
+        S3 object key (path within the bucket).
+    aws_profile
+        Optional AWS profile name to use for authentication.
+
+    Raises
+    ------
+    ClientError
+        If there are S3 access issues.
+    """
+    session = boto3.Session(profile_name=aws_profile)
+    s3_client = session.client("s3")
+
+    logging.info(f"Uploading to s3://{bucket_name}/{key}")
+    s3_client.put_object(
+        Bucket=bucket_name,
+        Key=key,
+        Body=json.dumps(data),
+        ContentType="application/json",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.12.0"
 dynamic = ["version"]
 
 dependencies = [
+  "boto3",
   "jupyter>=1.1.1",
   "movement>=0.17.0",
   "sleap-io>=0.7.1",

--- a/tests/test_unit/test_clips.py
+++ b/tests/test_unit/test_clips.py
@@ -7,11 +7,14 @@ import pytest
 
 from poseinterface.clips import (
     _extract_cliplabels,
+    _extract_startlabels_from_dict,
     _uniform_start_frames,
     _validate_clip_request,
     extract_clips,
     extract_clips_uniform,
     extract_single_clip,
+    extract_startlabels,
+    extract_startlabels_s3,
     main,
     parse_args,
     wrapper,
@@ -326,6 +329,121 @@ def test_extract_clips_uniform(
             dur_clips,
             sf,
         )
+
+
+# ---------------------------------------------------------------------------
+# extract_startlabels
+# ---------------------------------------------------------------------------
+
+
+def test_extract_startlabels(video_labels):
+    """Test start labels contain only the first frame and its annotations."""
+    start_labels = _extract_startlabels_from_dict(video_labels)
+    first_frame_annotations = [
+        annotation
+        for annotation in video_labels["annotations"]
+        if annotation["image_id"] == 0
+    ]
+
+    assert start_labels["images"] == [{"id": 0}]
+    assert start_labels["annotations"] == first_frame_annotations
+    assert start_labels["categories"] == video_labels["categories"]
+
+
+def test_extract_startlabels_requires_first_frame(video_labels):
+    """Test start-label extraction validates the presence of frame 0."""
+    clip_labels = {
+        **video_labels,
+        "images": [{"id": 1}],
+        "annotations": [{"image_id": 1, "id": 1}],
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Clip labels must contain exactly one first-frame image with id 0"
+        ),
+    ):
+        _extract_startlabels_from_dict(clip_labels)
+
+
+@pytest.fixture
+def cliplabels_path(tmp_path, video_labels):
+    """A valid ``*_cliplabels.json`` file on disk."""
+    path = tmp_path / "sub-01_ses-01_cam-01_start-0_dur-10_cliplabels.json"
+    path.write_text(json.dumps(video_labels))
+    return path
+
+
+def test_extract_startlabels_writes_file(cliplabels_path):
+    """Test reading a cliplabels file and writing a startlabels file."""
+    output_path = extract_startlabels(cliplabels_path)
+
+    assert (
+        output_path.name
+        == "sub-01_ses-01_cam-01_start-0_dur-10_startlabels.json"
+    )
+    assert output_path.exists()
+    start_labels = json.loads(output_path.read_text())
+    assert start_labels["images"] == [{"id": 0}]
+    assert all(a["image_id"] == 0 for a in start_labels["annotations"])
+
+
+def test_extract_startlabels_custom_output_path(tmp_path, cliplabels_path):
+    """Test an explicit output_path is honoured."""
+    output_path = tmp_path / "custom_startlabels.json"
+    result = extract_startlabels(cliplabels_path, output_path=output_path)
+
+    assert result == output_path
+    assert output_path.exists()
+
+
+def test_extract_startlabels_missing_input(tmp_path):
+    """Test a missing input file raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        extract_startlabels(tmp_path / "absent_cliplabels.json")
+
+
+def test_extract_startlabels_bad_input_suffix(tmp_path, video_labels):
+    """Test an input not ending in _cliplabels.json is rejected."""
+    path = tmp_path / "sub-01_ses-01_cam-01_framelabels.json"
+    path.write_text(json.dumps(video_labels))
+    with pytest.raises(ValueError, match="_cliplabels.json"):
+        extract_startlabels(path)
+
+
+def test_extract_startlabels_bad_output_suffix(tmp_path, cliplabels_path):
+    """Test an output not ending in _startlabels.json is rejected."""
+    with pytest.raises(ValueError, match="_startlabels.json"):
+        extract_startlabels(
+            cliplabels_path, output_path=tmp_path / "wrong.json"
+        )
+
+
+def test_extract_startlabels_s3(video_labels):
+    """Test S3 extraction downloads, extracts, and uploads to the right key."""
+    uri = "s3://my-bucket/Test/proj/Clips/sub-01_ses-01_cam-01_cliplabels.json"
+    with (
+        patch(
+            "poseinterface.clips.s3.download_json_from_s3",
+            return_value=video_labels,
+        ) as mock_download,
+        patch("poseinterface.clips.s3.upload_json_to_s3") as mock_upload,
+    ):
+        result = extract_startlabels_s3(uri)
+
+    mock_download.assert_called_once_with(
+        "my-bucket",
+        "Test/proj/Clips/sub-01_ses-01_cam-01_cliplabels.json",
+        None,
+    )
+    uploaded_data, bucket, key, _ = mock_upload.call_args.args
+    assert uploaded_data["images"] == [{"id": 0}]
+    assert bucket == "my-bucket"
+    assert key == "Test/proj/Clips/sub-01_ses-01_cam-01_startlabels.json"
+    assert result == (
+        "s3://my-bucket/Test/proj/Clips/sub-01_ses-01_cam-01_startlabels.json"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_unit/test_s3.py
+++ b/tests/test_unit/test_s3.py
@@ -1,0 +1,23 @@
+import pytest
+
+from poseinterface.s3 import parse_s3_uri
+
+
+def test_parse_s3_uri():
+    """Test a valid S3 URI is split into bucket and key."""
+    bucket, key = parse_s3_uri("s3://my-bucket/path/to/file_cliplabels.json")
+    assert bucket == "my-bucket"
+    assert key == "path/to/file_cliplabels.json"
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "my-bucket/path/to/file.json",  # missing s3:// scheme
+        "s3://my-bucket",  # missing key
+    ],
+)
+def test_parse_s3_uri_invalid(uri):
+    """Test malformed S3 URIs raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid S3 URI format"):
+        parse_s3_uri(uri)


### PR DESCRIPTION
Adds two new functions to extract only the first frame's labels from cliplabels.json files:
- extract_start_frames_label: processes local files
- extract_start_frames_label_s3: processes files on S3 (requires boto3)

Both functions read *_cliplabels.json files and create corresponding *_startlabels.json files containing only labels for frame id=0.

Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [X ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR addresses the first step in the issue https://github.com/neuroinformatics-unit/poseinterface/issues/63 which is a script for copying benchmark data from the temporary location to the benchmark location. 

**What does this PR do?**
This script adds a function forstripping the cliplabels file and creating a new file that only contains the first label of the frame which will be shared in the benchmark for the Test data.

## References

https://github.com/neuroinformatics-unit/poseinterface/issues/63

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

No 

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the
documentation has been updated.

## Checklist:

- [ X] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
