### PR TITLE
Publish to PyPI via pypa action directly

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -56,6 +56,11 @@ jobs:
     needs: [build_sdist_wheels]
     runs-on: ubuntu-latest
     steps:
-    - uses: neuroinformatics-unit/actions/upload_pypi@v2
+    - uses: actions/download-artifact@v8
       with:
-        secret-pypi-key: ${{ secrets.TWINE_API_KEY }}
+        name: artifact
+        path: dist
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TWINE_API_KEY }}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -55,12 +55,14 @@ jobs:
     name: Publish build distributions
     needs: [build_sdist_wheels]
     runs-on: ubuntu-latest
+    environment: # use Trusted Publisher route
+      name: pypi
+      url: https://pypi.org/p/poseinterface
+    permissions:
+      id-token: write
     steps:
     - uses: actions/download-artifact@v8
       with:
         name: artifact
         path: dist
     - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.TWINE_API_KEY }}

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -121,6 +121,7 @@ A GitHub actions workflow (`.github/workflows/test_and_deploy.yml`) has been set
 * Linting checks (pre-commit).
 * Testing (only if linting checks pass)
 * Release to PyPI (only if a git tag is present and if tests pass).
+  Release tags must follow the `vX.Y.Z` format, e.g. `v0.1.0`.
 
 Another workflow (`.github/workflows/docs_build_and_deploy.yml`) is set up to build and deploy the documentation to GitHub pages on each push to `main` and on releases (i.e. when a git tag is present).
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

`upload_pypi@v2` failed at the publish step with a Docker error before it ever contacted PyPI. I hit this while releasing `poseinterface` v0.1.0, so I published that release manually as a workaround.

**Failed job:** https://github.com/neuroinformatics-unit/poseinterface/actions/runs/29440557606/job/87439010800

We had hit this issue before in other projects: see https://github.com/neuroinformatics-unit/actions/issues/76.

**What does this PR do?**

All of our packages now use the `pypa/gh-action-pypi-publish` action directly, to avoid that exact failure.
This PR aligns the PyPI release step with [that of `movement`](https://github.com/neuroinformatics-unit/movement/blob/main/.github/workflows/test_and_deploy.yml), which we know works.

The faulty workflow was inherited from the python-cookiecutter (see existing https://github.com/neuroinformatics-unit/python-cookiecutter/issues/173).

## References

existing actions issue: https://github.com/neuroinformatics-unit/actions/issues/76
existing cookiecutter issue: https://github.com/neuroinformatics-unit/python-cookiecutter/issues/173

## How has this PR been tested?

The real test will be the next release, but we know the same workflow is functional for dozens of other packages.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)

---

## UPDATED: 2026-07-27

Following @lochhh's [review suggestion](https://github.com/neuroinformatics-unit/poseinterface/pull/67#pullrequestreview-4737291555), this PR now also switches PyPI releases to [Trusted Publishing](https://docs.pypi.org/trusted-publishers/), rather than only swapping out the broken `upload_pypi@v2`.

**What changed since the original description:**

- **On PyPI:** `poseinterface` is configured with a trusted publisher pointing at this repo's `test_and_deploy.yml`, with `pypi` as the environment name.
- **In the workflow:** `upload_all` declares the `pypi` environment and `id-token: write`; the `user`/`password` inputs are gone. No long-lived API token is involved in publishing anymore.
- **In repository Settings > Environments:** Added a `pypi` environment with a deployment tag rule to only allow tags matching `v*`
- **In the docs:** `contributing.md` now states that release tags follow the `vX.Y.Z` format.
