### PR TITLE
Add installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ source .venv/bin/activate  # On macOS and Linux
 .venv\Scripts\activate     # On Windows PowerShell
 ```
 
-Then, install the package directly from the `main` branch on GitHub:
+Then, install the package from PyPI:
+
+```bash
+uv pip install poseinterface
+```
+
+Or directly from the `main` branch on GitHub:
 
 ```bash
 uv pip install git+https://github.com/neuroinformatics-unit/poseinterface.git@main

--- a/README.md
+++ b/README.md
@@ -27,27 +27,12 @@ Read the [documentation](https://poseinterface.neuroinformatics.dev/) for more i
 
 ## Installation
 
-We recommend installing `poseinterface` in a virtual environment, using [uv](https://docs.astral.sh/uv/).
-
-In your working directory, create a new environment and activate it:
-
 ```bash
-uv venv --python=3.13
-source .venv/bin/activate  # On macOS and Linux
-.venv\Scripts\activate     # On Windows PowerShell
+pip install poseinterface
 ```
 
-Then, install the package from PyPI:
-
-```bash
-uv pip install poseinterface
-```
-
-Or directly from the `main` branch on GitHub:
-
-```bash
-uv pip install git+https://github.com/neuroinformatics-unit/poseinterface.git@main
-```
+See the [installation guide](https://poseinterface.neuroinformatics.dev/installation.html)
+for more details.
 
 If you would like to contribute, see the
 [contributing guide](https://poseinterface.neuroinformatics.dev/contributing.html),

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -16,6 +16,13 @@ tools for running and comparing pose estimation and tracking methods.
 Learn about the project's mission, team and how to contribute.
 :::
 
+:::{grid-item-card} {fas}`download;sd-text-primary` Installation
+:link: installation
+:link-type: doc
+
+How to install the `poseinterface` package.
+:::
+
 :::{grid-item-card} {fas}`database;sd-text-primary` Benchmark dataset
 :link: benchmark-dataset
 :link-type: doc
@@ -46,6 +53,7 @@ Public functions and classes in `poseinterface`.
 :hidden:
 
 about
+installation
 benchmark-dataset
 auto_examples/index
 api_index

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -37,12 +37,6 @@ Folder structure and file naming conventions for benchmark datasets.
 A gallery of examples using `poseinterface`.
 :::
 
-:::{grid-item-card} {fas}`book;sd-text-primary` API reference
-:link: api_index
-:link-type: doc
-
-Public functions and classes in `poseinterface`.
-:::
 ::::
 
 ![](_static/poseinterface_overview.png)

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -9,7 +9,7 @@ The instructions below use [uv](https://docs.astral.sh/uv/), but feel free to us
 In your working directory, create and activate a new environment:
 
 ```sh
-uv venv --python=3.13
+uv venv --python=">=3.12"
 source .venv/bin/activate  # On macOS and Linux
 .venv\Scripts\activate     # On Windows PowerShell
 ```

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -1,0 +1,47 @@
+(target-installation)=
+# Installation
+
+## Create a virtual environment
+
+We recommend installing `poseinterface` in a virtual environment.
+The instructions below use [uv](https://docs.astral.sh/uv/), but feel free to use any virtual-environment tool you are familiar with, including [conda](https://docs.conda.io/).
+
+In your working directory, create and activate a new environment:
+
+```sh
+uv venv --python=3.13
+source .venv/bin/activate  # On macOS and Linux
+.venv\Scripts\activate     # On Windows PowerShell
+```
+
+## Install the package
+
+With your environment activated, install `poseinterface` from PyPI:
+
+```sh
+uv pip install poseinterface
+```
+
+Or directly from the `main` branch on GitHub:
+
+```sh
+uv pip install git+https://github.com/neuroinformatics-unit/poseinterface.git@main
+```
+
+`uv` may be omitted from these commands if it is not available;
+`pip install ...` works in any standard virtual environment.
+
+## Update the package
+
+To update to the latest release:
+
+```sh
+uv pip install -U poseinterface
+```
+
+:::{admonition} For developers
+:class: tip
+
+If you would like to contribute to `poseinterface`, see the
+[contributing guide](target-contributing) for developer setup instructions.
+:::

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -16,13 +16,13 @@ source .venv/bin/activate  # On macOS and Linux
 
 ## Install the package
 
-With your environment activated, install `poseinterface` from PyPI:
+With your environment activated, install the latest release of `poseinterface` from PyPI:
 
 ```sh
 uv pip install poseinterface
 ```
 
-Or directly from the `main` branch on GitHub:
+Or, to get the latest development version from the `main` branch on GitHub:
 
 ```sh
 uv pip install git+https://github.com/neuroinformatics-unit/poseinterface.git@main
@@ -43,5 +43,6 @@ uv pip install -U poseinterface
 :class: tip
 
 If you would like to contribute to `poseinterface`, see the
-[contributing guide](target-contributing) for developer setup instructions.
+[contributing guide](target-contributing) for developer setup instructions
+and coding guidelines.
 :::


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: docs

**Why is this PR needed?**

Now that the package is on PyPI, it's a good time to update installation instructions.
See #66 

**What does this PR do?**

Adds a minimal installation guide as a standalone page on the website.
The installation section of the README now simply say `pip install poseinterface` and directs readers to the website for more details (the link will go live once this PR gets merged).

Because I wanted to make space for an 'Installation' card on the homepage, I removed the 'API reference' card. 5 cards is probably too many and it's more important to have 'installation' prominent imo. The API reference can still be accessed from the navbar.

## References

Closes #66 

## How has this PR been tested?

Local docs build.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
