### PR TITLE
Remove duplicated check-manifest step

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -14,14 +14,8 @@ jobs:
     steps:
       - uses: neuroinformatics-unit/actions/lint@v2
 
-  manifest:
-    name: Check Manifest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: neuroinformatics-unit/actions/check_manifest@v2
-
   test:
-    needs: [linting, manifest]
+    needs: [linting]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
check-manifest is run twice on CI

**What does this PR do?**
This PR removes the manifest job from test_and_deploy.yml, keeping the one in pre-commit-config.yaml, so that we can get fast feedback locally, and pre-commit.ci will also run this check remotely. This keeps the CI steps simple.

## References
https://github.com/neuroinformatics-unit/movement/issues/743
https://github.com/neuroinformatics-unit/movement/pull/744

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
